### PR TITLE
Base isAccessibleForFree on actual accessLevel

### DIFF
--- a/test/types/article.spec.js
+++ b/test/types/article.spec.js
@@ -20,21 +20,21 @@ describe('Type: Article', function () {
 			expect(result.publisher).to.deep.equal({ '@type': 'Organization', '@context': 'http://schema.org', name: 'ft' });
 		});
 
-		it('sets isAccessibleForFree based upon content.freeArticle', function () {
-			const result = article({ freeArticle: true });
+		it('sets isAccessibleForFree based upon content.accessLevel', function () {
+			const result = article({ accessLevel: 'free' });
 			expect(result.isAccessibleForFree).to.equal('True');
 		});
 
 		context('sets isPartOf.productID based upon content.accessLevel', function () {
 
 			it('free content', function () {
-				const result = article({ freeArticle: true, accessLevel: 'free' });
+				const result = article({ accessLevel: 'free' });
 				expect(result.isAccessibleForFree).to.equal('True');
 				expect(result.isPartOf.productID).to.equal('freeEntitlement');
 			});
 
 			it('paywalled content', function () {
-				const result = article({ freeArticle: false, accessLevel: 'premium' });
+				const result = article({ accessLevel: 'premium' });
 				expect(result.isAccessibleForFree).to.equal('False');
 				expect(result.isPartOf.productID).to.equal('premiumEntitlement');
 			});

--- a/types/article.js
+++ b/types/article.js
@@ -18,7 +18,7 @@ module.exports = (content) => {
 		'datePublished': content.initialPublishedDate ? content.initialPublishedDate : content.publishedDate,
 		'dateModified': content.publishedDate,
 		'description': content.description,
-		'isAccessibleForFree': content.freeArticle ? 'True' : 'False'
+		'isAccessibleForFree': content.accessLevel && content.accessLevel === 'free' ? 'True' : 'False'
 	};
 
 	Object.assign(baseSchema, { isPartOf: product(ftData, content) });

--- a/types/barrier.js
+++ b/types/barrier.js
@@ -10,7 +10,7 @@ module.exports = (content) => {
 	};
 
 	if (content && content.accessLevel) {
-		Object.assign(baseSchema, { 'isAccessibleForFree': content && content.freeArticle ? 'True' : 'False' });
+		Object.assign(baseSchema, { 'isAccessibleForFree': content && content.accessLevel && content.accessLevel === 'free' ? 'True' : 'False' });
 	}
 
 	Object.assign(baseSchema, { isPartOf: product(ftData, content) });


### PR DESCRIPTION
Rather than use an arbitrary "freeArticle" boolean as only defined
on article pages, use the actual accessLevel value to determine
the value of isAccessibleForFree
 🐿 v2.5.16