### PR TITLE
markup statndalone barriers as "CreativeWork"

### DIFF
--- a/test/types/article.spec.js
+++ b/test/types/article.spec.js
@@ -1,23 +1,15 @@
 const { expect } = require('chai');
-const proxyquire = require('proxyquire').noCallThru();
+const article = require('../../types/article');
 
 describe('Type: Article', function () {
-	const mockCompany = { prefLabel: 'ft', entitlements: { free: 'freeEntitlement', premium: 'premiumEntitlement' } };
-	let article;
-
-	beforeEach(function () {
-		article = proxyquire('../../types/article', {
-			'../data/ft': mockCompany
-		});
-	});
 
 	context('Subscribe with Google', function () {
 
 		it('has correct base format', function () {
 			const result = article({});
 			expect(result.isAccessibleForFree).to.equal('False');
-			expect(result.isPartOf).to.deep.equal({ '@type': [ 'CreativeWork', 'Product' ], name: 'ft' });
-			expect(result.publisher).to.deep.equal({ '@type': 'Organization', '@context': 'http://schema.org', name: 'ft' });
+			expect(result.isPartOf).to.deep.equal({ '@type': [ 'CreativeWork', 'Product' ], name: 'Financial Times' });
+			expect(result.publisher).to.contain({ '@type': 'Organization', '@context': 'http://schema.org', name: 'Financial Times' });
 		});
 
 		it('sets isAccessibleForFree based upon content.accessLevel', function () {
@@ -30,13 +22,13 @@ describe('Type: Article', function () {
 			it('free content', function () {
 				const result = article({ accessLevel: 'free' });
 				expect(result.isAccessibleForFree).to.equal('True');
-				expect(result.isPartOf.productID).to.equal('freeEntitlement');
+				expect(result.isPartOf.productID).to.equal('ft.com:free');
 			});
 
 			it('paywalled content', function () {
 				const result = article({ accessLevel: 'premium' });
 				expect(result.isAccessibleForFree).to.equal('False');
-				expect(result.isPartOf.productID).to.equal('premiumEntitlement');
+				expect(result.isPartOf.productID).to.equal('ft.com:premium');
 			});
 
 		});

--- a/test/types/article.spec.js
+++ b/test/types/article.spec.js
@@ -8,6 +8,7 @@ describe('Type: Article', function () {
 		it('has correct base format', function () {
 			const result = article({});
 			expect(result.isAccessibleForFree).to.equal('False');
+			expect(result['@type']).to.equal('NewsArticle');
 			expect(result.isPartOf).to.deep.equal({ '@type': [ 'CreativeWork', 'Product' ], name: 'Financial Times' });
 			expect(result.publisher).to.contain({ '@type': 'Organization', '@context': 'http://schema.org', name: 'Financial Times' });
 		});

--- a/test/types/barrier.spec.js
+++ b/test/types/barrier.spec.js
@@ -14,8 +14,9 @@ describe('Type: Barrier', function () {
 	context('standalone barrier (aka product selector)', function () {
 
 		it('has correct base format', function () {
-			const result = barrier({});
+			const result = barrier();
 			expect(result.isAccessibleForFree).to.be.undefined;
+			expect(result['@type']).to.equal('CreativeWork');
 			expect(result.isPartOf).to.deep.equal({ '@type': [ 'CreativeWork', 'Product' ], name: 'ft' });
 			expect(result.publisher).to.deep.equal({ '@type': 'Organization', '@context': 'http://schema.org', name: 'ft' });
 		});

--- a/test/types/barrier.spec.js
+++ b/test/types/barrier.spec.js
@@ -30,16 +30,18 @@ describe('Type: Barrier', function () {
 		});
 
 		it('has correct base format with data pertaining to requested content', function () {
-			const result = barrier(mergeWithArticle({ accessLevel: 'foo' }));
+			const result = barrier(mergeWithArticle({ accessLevel: 'free' }));
 			expect(result['@type']).to.equal('NewsArticle');
-			expect(result.isAccessibleForFree).to.equal('False');
-			expect(result.isPartOf).to.deep.equal({ '@type': [ 'CreativeWork', 'Product' ], name: 'Financial Times' });
+			expect(result.isAccessibleForFree).to.equal('True');
+			expect(result.isPartOf['@type']).to.eql(['CreativeWork', 'Product']);
+			expect(result.isPartOf).to.contain({ name: 'Financial Times', productID: 'ft.com:free' });
 			expect(result.publisher).to.contain({ '@type': 'Organization', '@context': 'http://schema.org', name: 'Financial Times' });
 		});
 
 		it('wont add productID entitlements label if no matching content.accessLevel', function () {
 			const result = barrier(mergeWithArticle({ accessLevel: 'foo' }));
 			expect(result['@type']).to.equal('NewsArticle');
+			expect(result.isAccessibleForFree).to.equal('False');
 			expect(result.isPartOf).to.deep.equal({ '@type': [ 'CreativeWork', 'Product' ], name: 'Financial Times' });
 		});
 
@@ -47,6 +49,7 @@ describe('Type: Barrier', function () {
 			const mockContent = mergeWithArticle({ accessLevel: 'premium' });
 			const result = barrier(mockContent);
 			expect(result['@type']).to.equal('NewsArticle');
+			expect(result.isAccessibleForFree).to.equal('False');
 			expect(result.isPartOf.productID).to.equal('ft.com:premium');
 		});
 

--- a/test/types/barrier.spec.js
+++ b/test/types/barrier.spec.js
@@ -1,15 +1,11 @@
 const { expect } = require('chai');
-const proxyquire = require('proxyquire').noCallThru();
+const barrier = require('../../types/barrier');
+
+const mockArticle = require('../fixtures/article.json');
+
+const mergeWithArticle = (data) => Object.assign({}, mockArticle, data);
 
 describe('Type: Barrier', function () {
-	const mockCompany = { prefLabel: 'ft', entitlements: { premium: 'premiumEntitlement' } };
-	let barrier;
-
-	beforeEach(function () {
-		barrier = proxyquire('../../types/barrier', {
-			'../data/ft': mockCompany
-		});
-	});
 
 	context('standalone barrier (aka product selector)', function () {
 
@@ -17,30 +13,38 @@ describe('Type: Barrier', function () {
 			const result = barrier();
 			expect(result.isAccessibleForFree).to.be.undefined;
 			expect(result['@type']).to.equal('CreativeWork');
-			expect(result.isPartOf).to.deep.equal({ '@type': [ 'CreativeWork', 'Product' ], name: 'ft' });
-			expect(result.publisher).to.deep.equal({ '@type': 'Organization', '@context': 'http://schema.org', name: 'ft' });
+			expect(result.isPartOf).to.deep.equal({ '@type': [ 'CreativeWork', 'Product' ], name: 'Financial Times' });
+			expect(result.publisher).to.contain({ '@type': 'Organization', '@context': 'http://schema.org', name: 'Financial Times' });
 		});
 
 	});
 
 	context('content paywall', function () {
 
+		it('will not add newsArticle markup if not enough data is passed', function () {
+			const result = barrier({});
+			expect(result.isAccessibleForFree).to.be.undefined;
+			expect(result['@type']).to.equal('CreativeWork');
+			expect(result.isPartOf).to.deep.equal({ '@type': [ 'CreativeWork', 'Product' ], name: 'Financial Times' });
+			expect(result.publisher).to.contain({ '@type': 'Organization', '@context': 'http://schema.org', name: 'Financial Times' });
+		});
+
 		it('has correct base format with data pertaining to requested content', function () {
-			const result = barrier({ accessLevel: 'foo' });
+			const result = barrier(mergeWithArticle({ accessLevel: 'foo' }));
 			expect(result.isAccessibleForFree).to.equal('False');
-			expect(result.isPartOf).to.deep.equal({ '@type': [ 'CreativeWork', 'Product' ], name: 'ft' });
-			expect(result.publisher).to.deep.equal({ '@type': 'Organization', '@context': 'http://schema.org', name: 'ft' });
+			expect(result.isPartOf).to.deep.equal({ '@type': [ 'CreativeWork', 'Product' ], name: 'Financial Times' });
+			expect(result.publisher).to.contain({ '@type': 'Organization', '@context': 'http://schema.org', name: 'Financial Times' });
 		});
 
 		it('wont add productID entitlements label if no matching content.accessLevel', function () {
-			const result = barrier({ accessLevel: 'foo' });
-			expect(result.isPartOf).to.deep.equal({ '@type': [ 'CreativeWork', 'Product' ], name: 'ft' });
+			const result = barrier(mergeWithArticle({ accessLevel: 'foo' }));
+			expect(result.isPartOf).to.deep.equal({ '@type': [ 'CreativeWork', 'Product' ], name: 'Financial Times' });
 		});
 
 		it('correctly formats productId entitlements label based upon content.accessLevel', function () {
-			const mockContent = { accessLevel: 'premium' };
+			const mockContent = mergeWithArticle({ accessLevel: 'premium' });
 			const result = barrier(mockContent);
-			expect(result.isPartOf.productID).to.equal('premiumEntitlement');
+			expect(result.isPartOf.productID).to.equal('ft.com:premium');
 		});
 
 	});

--- a/test/types/barrier.spec.js
+++ b/test/types/barrier.spec.js
@@ -31,6 +31,7 @@ describe('Type: Barrier', function () {
 
 		it('has correct base format with data pertaining to requested content', function () {
 			const result = barrier(mergeWithArticle({ accessLevel: 'foo' }));
+			expect(result['@type']).to.equal('NewsArticle');
 			expect(result.isAccessibleForFree).to.equal('False');
 			expect(result.isPartOf).to.deep.equal({ '@type': [ 'CreativeWork', 'Product' ], name: 'Financial Times' });
 			expect(result.publisher).to.contain({ '@type': 'Organization', '@context': 'http://schema.org', name: 'Financial Times' });
@@ -38,12 +39,14 @@ describe('Type: Barrier', function () {
 
 		it('wont add productID entitlements label if no matching content.accessLevel', function () {
 			const result = barrier(mergeWithArticle({ accessLevel: 'foo' }));
+			expect(result['@type']).to.equal('NewsArticle');
 			expect(result.isPartOf).to.deep.equal({ '@type': [ 'CreativeWork', 'Product' ], name: 'Financial Times' });
 		});
 
 		it('correctly formats productId entitlements label based upon content.accessLevel', function () {
 			const mockContent = mergeWithArticle({ accessLevel: 'premium' });
 			const result = barrier(mockContent);
+			expect(result['@type']).to.equal('NewsArticle');
 			expect(result.isPartOf.productID).to.equal('ft.com:premium');
 		});
 

--- a/types/barrier.js
+++ b/types/barrier.js
@@ -6,7 +6,7 @@ const product = require('./product');
 const ftData = require('../data/ft');
 
 const hasMinimumContentData = (data) => {
-	const requiredKeys = [ 'title', 'authors', 'publishedDate', 'mainImage' ];
+	const requiredKeys = [ 'title', 'authors', 'publishedDate', 'mainImage', 'accessLevel' ];
 	return requiredKeys.every(key => data[key]);
 };
 

--- a/types/barrier.js
+++ b/types/barrier.js
@@ -1,17 +1,18 @@
 'use strict';
 
+const article = require('./article');
 const organization = require('./organization');
 const product = require('./product');
 const ftData = require('../data/ft');
 
 module.exports = (content) => {
-	let baseSchema = {
-		'@context': 'http://schema.org'
-	};
+	/* if passed article content markup as if article */
+	if (content) return article(content);
 
-	if (content && content.accessLevel) {
-		Object.assign(baseSchema, { 'isAccessibleForFree': content && content.accessLevel && content.accessLevel === 'free' ? 'True' : 'False' });
-	}
+	let baseSchema = {
+		'@context': 'http://schema.org',
+		'@type': 'CreativeWork'
+	};
 
 	Object.assign(baseSchema, { isPartOf: product(ftData, content) });
 

--- a/types/barrier.js
+++ b/types/barrier.js
@@ -5,9 +5,14 @@ const organization = require('./organization');
 const product = require('./product');
 const ftData = require('../data/ft');
 
+const hasMinimumContentData = (data) => {
+	const requiredKeys = [ 'title', 'authors', 'publishedDate', 'mainImage' ];
+	return requiredKeys.every(key => data[key]);
+};
+
 module.exports = (content) => {
-	/* if passed article content markup as if article */
-	if (content) return article(content);
+	/* if passed article content markup as article */
+	if (content && hasMinimumContentData(content)) return article(content);
 
 	let baseSchema = {
 		'@context': 'http://schema.org',


### PR DESCRIPTION
Markup content paywall barriers as the `NewsArticle` to which they pertain.

 🐿 v2.5.16

