### PR TITLE
[SP-267] Use https for ft logo

### DIFF
--- a/data/ft.js
+++ b/data/ft.js
@@ -2,7 +2,7 @@ module.exports = {
 	prefLabel: 'Financial Times',
 	legalName: 'The Financial Times Ltd.',
 	logo: {
-		url: 'http://im.ft-static.com/m/img/masthead_main.jpg',
+		url: 'https://im.ft-static.com/m/img/masthead_main.jpg',
 		width: 435,
 		height: 36
 	},


### PR DESCRIPTION
Within Spark, we are seeing that when we embed an ft link, the page gets set to "Not Secure":

<img width="290" alt="Screenshot 2020-04-09 at 4 54 31 pm" src="https://user-images.githubusercontent.com/79451/78914774-ceacf500-7a82-11ea-9fc7-5f0fad26352a.png">

This is because we are retrieving a preview of the page, and getting the publisher logo which is set to `http://im.ft-static.com/m/img/masthead_main.jpg`, which is _not_ `https` while Spark is.

From searching the [ft org on github](https://github.com/search?q=org%3AFinancial-Times+https%3A%2F%2Fim.ft-static.com%2Fm%2Fimg%2Fmasthead_main.jpg&type=Code), this seems like the place where it is coming from, so hopefully this is the right place to change it. From what I can gather the `https` form of the url works: https://im.ft-static.com/m/img/masthead_main.jpg, and there shouldn't be anything bad that could happen from this change, as `http` pages viewing `https` images should be fine - but I could be wrong 😬 

Anyone have any ideas?

/cc @Financial-Times/digital-newsroom 

On slack: https://financialtimes.slack.com/archives/CLQP9R9NK/p1586337416385700
