### PR TITLE
Upgrade html-to-text to version 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "snyk": "^1.168.0"
   },
   "dependencies": {
-    "html-to-text": "^2.1.3",
+    "html-to-text": "^3.0.0",
     "wordcount": "^1.1.1"
   },
   "scripts": {


### PR DESCRIPTION
Version 3 includes an upgrade to the package used to parse HTML from `htmlparser` to `htmlparser2`, this [includes performance increases](https://github.com/fb55/htmlparser2#performance) that may improve this packages overall performance removing bottle necks from some consumer applications.

Changelog: https://github.com/html-to-text/node-html-to-text/blob/master/CHANGELOG.md#version-300