### PR TITLE
Upgrade from Node 8 to Node 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,15 @@
 
 references:
 
-  container_config_node8: &container_config_node8
+  container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:8-browsers
+      - image: circleci/node:12-browsers
 
-  container_config_lambda_node8: &container_config_lambda_node8
+  container_config_lambda_node: &container_config_lambda_node
     working_directory: ~/project/build
     docker:
-      - image: lambci/lambda:build-nodejs8.10
+      - image: lambci/lambda:build-nodejs12.x
 
   workspace_root: &workspace_root
     ~/project
@@ -22,13 +22,13 @@ references:
 
   npm_cache_keys: &npm_cache_keys
     keys:
-        - v10-dependency-npm-{{ checksum "package.json" }}-
-        - v10-dependency-npm-{{ checksum "package.json" }}
-        - v10-dependency-npm-
+        - v11-dependency-npm-{{ checksum "package.json" }}-
+        - v11-dependency-npm-{{ checksum "package.json" }}
+        - v11-dependency-npm-
 
   cache_npm_cache: &cache_npm_cache
     save_cache:
-        key: v10-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
+        key: v11-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
         paths:
         - ./node_modules/
 
@@ -60,7 +60,7 @@ version: 2
 jobs:
 
   build:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - checkout
       - run:
@@ -93,7 +93,7 @@ jobs:
             - build
 
   test:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:
@@ -109,7 +109,7 @@ jobs:
           destination: test-results
 
   publish:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
     "prepush": "make verify -j3",
     "prepare": "npx snyk protect || npx snyk protect -d || true"
+  },
+  "engines": {
+    "node": "12.x"
   }
 }


### PR DESCRIPTION
Fix Snyk Monitoring from failing by using newer version of Node in CI, will unblock publishing.