### PR TITLE
Check if can use bodyText for articleBody

### DIFF
--- a/test/types/article.spec.js
+++ b/test/types/article.spec.js
@@ -3,6 +3,27 @@ const article = require('../../types/article');
 
 describe('Type: Article', function () {
 
+	context('articleBody', function () {
+		it('doesnt return if no text or html available', function () {
+			const result = article({});
+			expect(result.articleBody).to.be.undefined;
+		});
+		it('defaults to body text if available', function () {
+			const result = article({
+				bodyText: 'Hello, World.',
+				bodyHTML: '<p>Hello I\'m <blink>HTML</blink>!</p>',
+			});
+			expect(result.articleBody).to.equal('Hello, World.');
+		});
+		it('turns body HTML into text if available', function () {
+			const result = article({
+				bodyHTML: '<p>Hello I\'m <blink>HTML</blink>!</p>',
+			});
+			expect(result.articleBody).to.equal('Hello I\'m HTML!');
+		});
+	});
+
+
 	context('Subscribe with Google', function () {
 
 		it('has correct base format', function () {

--- a/types/article.js
+++ b/types/article.js
@@ -8,6 +8,17 @@ const organization = require('./organization');
 const product = require('./product');
 const ftData = require('../data/ft');
 
+function getArticleBody (content) {
+	if (content.bodyText) {
+		return content.bodyText;
+	}
+
+	if (content.bodyHTML) {
+		return htmlToText.fromString(content.bodyHTML, {ignoreHref: true});
+	}
+
+	return '';
+}
 
 module.exports = (content) => {
 	let baseSchema = {
@@ -37,9 +48,9 @@ module.exports = (content) => {
 		});
 	}
 
-	if (content.bodyHTML) {
-		const text = htmlToText.fromString(content.bodyHTML, {ignoreHref: true});
-		Object.assign(baseSchema, {articleBody: text, wordCount: wordcount(text)});
+	const articleBody = getArticleBody(content);
+	if (articleBody) {
+		Object.assign(baseSchema, { articleBody, wordCount: wordcount(articleBody) });
 	}
 
 	Object.assign(baseSchema, { publisher: organization(ftData) });


### PR DESCRIPTION
Parsing large amounts of HTML can be very slow, if the content already has plain text to use (`bodyText` property) then use that instead before parsing HTML.