### PR TITLE
added liveblog update field to liveblog type

### DIFF
--- a/test/fixtures/liveblog.json
+++ b/test/fixtures/liveblog.json
@@ -1,0 +1,32 @@
+{
+    "posts": [
+        {
+            "standout": {
+                "breakingNews": false,
+                "editorsChoice": false,
+                "exclusive": false,
+                "scoop": false
+            },
+            "webUrl": "https://www.ft.com/content",
+            "publishedDate": "2021-05-12T22:30:36.929Z",
+            "bodyHTML": "<p>Hello I'm <blink>HTML</blink>!</p>",
+            "title": "Lorem Ipsum",
+            "byline": "Anna Gross and John Burn-Murdoch in London, Amy Kazmin and Jyotsna Singh in New Delhi",
+            "url": "https://www.ft.com/content"
+        },
+        {
+            "standout": {
+                "breakingNews": false,
+                "editorsChoice": false,
+                "exclusive": false,
+                "scoop": false
+            },
+            "webUrl": "https://www.ft.com/content",
+            "publishedDate": "2021-05-12T22:29:42.706Z",
+            "bodyHTML": "<p>Lorem ipsum</p>",
+            "title": "Lorem ipsum",
+            "byline": "FT reporters",
+            "url": "https://www.ft.com/content"
+        }
+    ]
+}

--- a/test/types/liveblog.spec.js
+++ b/test/types/liveblog.spec.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const liveblog = require('../../types/liveblog');
+const { posts } = require('../fixtures/liveblog.json');
 
 describe('Type: liveBlogPosting', function () {
 
@@ -10,29 +11,29 @@ describe('Type: liveBlogPosting', function () {
 		});
 
 		it('should have the required fields when passed adequate data', () => {
-			const result = liveblog({'publishedDate': '2021-03-25T22:44:55.577Z','firstPublishedDate': '2021-03-25T00:14:12.161Z'});
+			const result = liveblog({ 'publishedDate': '2021-03-25T22:44:55.577Z', 'firstPublishedDate': '2021-03-25T00:14:12.161Z' });
 			expect(Object.keys(result)).to.include.members(['@type', 'headline', 'datePublished', 'dateModified', 'coverageStartTime', 'coverageEndTime']);
-			expect(result.isPartOf).to.deep.equal({ '@type': [ 'CreativeWork', 'Product' ], name: 'Financial Times' });
+			expect(result.isPartOf).to.deep.equal({ '@type': ['CreativeWork', 'Product'], name: 'Financial Times' });
 			expect(result.publisher).to.contain({ '@type': 'Organization', '@context': 'http://schema.org', name: 'Financial Times' });
 		});
 
 	});
 
-	context('live blog Description', function () {
+	context('Live blog Description', function () {
 
 		it('defaults to content.alternativeTitles.promotionalTitle if it exist', function () {
-			const result = liveblog({alternativeTitles : {promotionalTitle: 'I am an alternative title.'}});
+			const result = liveblog({ alternativeTitles: { promotionalTitle: 'I am an alternative title.' } });
 			expect(result.description).to.equal('I am an alternative title.');
 		});
 
 		it('defaults to topper.headline if content.alternativeTitles.promotionalTitle doesn\'t exist', function () {
-			const result = liveblog({topper: { headline: 'Hello, World.'}});
+			const result = liveblog({ topper: { headline: 'Hello, World.' } });
 			expect(result.description).to.equal('Hello, World.');
 		});
 
 		it('turns content.summary.bodyHTML to text if topper.headline && content.alternativeTitles.promotionalTitle doesn\'t exist', function () {
 			const result = liveblog({
-				summary: {bodyHTML: '<p>Hello I\'m <blink>HTML</blink>!</p>'},
+				summary: { bodyHTML: '<p>Hello I\'m <blink>HTML</blink>!</p>' },
 			});
 			expect(result.description).to.equal('Hello I\'m HTML!');
 		});
@@ -41,19 +42,19 @@ describe('Type: liveBlogPosting', function () {
 	context('Coverage times', function () {
 
 		it('should have the correct coverage times', () => {
-			const result = liveblog({'publishedDate': '2021-04-28T20:59:10+01:00','firstPublishedDate': '2021-04-28T20:59:10+01:00'});
+			const result = liveblog({ 'publishedDate': '2021-04-28T20:59:10+01:00', 'firstPublishedDate': '2021-04-28T20:59:10+01:00' });
 			expect(Object.keys(result)).to.include.members(['coverageStartTime', 'coverageEndTime']);
 			expect(result['coverageStartTime']).to.equal('2021-04-28T20:59:10+01:00');
 			expect(result['coverageEndTime']).to.equal('2021-04-28T21:00:10+01:00');
 		});
 
 		it('coverageEndTime should be a minute after coverageStartTime', () => {
-			const result = liveblog({'publishedDate': '2021-04-28T20:59:10+01:00','firstPublishedDate': '2021-04-28T20:59:10+01:00'});
+			const result = liveblog({ 'publishedDate': '2021-04-28T20:59:10+01:00', 'firstPublishedDate': '2021-04-28T20:59:10+01:00' });
 			expect(result['coverageEndTime']).to.equal('2021-04-28T21:00:10+01:00');
 		});
 
 		it('coverageEndTime should remain same day if published a minute before the end of the day', () => {
-			const result = liveblog({'publishedDate': '2021-04-28T23:59:10+01:00','firstPublishedDate': '2021-04-28T23:59:10+01:00'});
+			const result = liveblog({ 'publishedDate': '2021-04-28T23:59:10+01:00', 'firstPublishedDate': '2021-04-28T23:59:10+01:00' });
 			expect(Object.keys(result)).to.include.members(['coverageStartTime', 'coverageEndTime']);
 			expect(result['coverageEndTime']).to.equal('2021-04-28T23:59:59+01:00');
 		});
@@ -67,7 +68,7 @@ describe('Type: liveBlogPosting', function () {
 			const result = liveblog({});
 			expect(result.isAccessibleForFree).to.equal('False');
 			expect(result['@type']).to.equal('LiveBlogPosting');
-			expect(result.isPartOf).to.deep.equal({ '@type': [ 'CreativeWork', 'Product' ], name: 'Financial Times' });
+			expect(result.isPartOf).to.deep.equal({ '@type': ['CreativeWork', 'Product'], name: 'Financial Times' });
 			expect(result.publisher).to.contain({ '@type': 'Organization', '@context': 'http://schema.org', name: 'Financial Times' });
 		});
 
@@ -92,6 +93,17 @@ describe('Type: liveBlogPosting', function () {
 
 		});
 
+	});
+
+
+	context('liveBlogUpdate field', function () {
+		it('should have liveBlogUpdate field if liveblogpackage has posts field', () => {
+			const result = liveblog({ 'publishedDate': '2021-03-25T22:44:55.577Z', 'firstPublishedDate': '2021-03-25T00:14:12.161Z', posts });
+			expect(Array.isArray(result.liveBlogUpdate)).to.be.true;
+			expect(result.liveBlogUpdate).to.not.be.empty;
+			expect(Object.keys(result.liveBlogUpdate[0])).to.include.members(['@type', 'headline', 'datePublished', 'articleBody']);
+			expect(result.liveBlogUpdate[0].articleBody).to.equal('Hello I\'m HTML!');
+		});
 	});
 
 });

--- a/types/liveblog.js
+++ b/types/liveblog.js
@@ -56,6 +56,34 @@ function getLiveBlogDescription (content) {
 	return '';
 }
 
+function getLiveBlogPostingSchemaFromPost (post) {
+	let baseSchema = {
+		'@type': 'BlogPosting'
+	};
+
+	if (post.title) {
+		baseSchema.headline = post.title;
+	}
+
+	if (post.publishedDate) {
+		baseSchema.datePublished = post.publishedDate;
+	}
+
+	if (post.mainImage) {
+		baseSchema.image = post.mainImage.url;
+	}
+
+	if (post.url || post.webUrl) {
+		baseSchema.url = post.url || post.webUrl;
+	}
+
+	if (post.bodyHTML) {
+		baseSchema.articleBody = htmlToText.fromString(post.bodyHTML);
+	}
+
+	return baseSchema;
+}
+
 module.exports = (content) => {
 	let baseSchema = {
 		'@context': 'http://schema.org',
@@ -81,6 +109,13 @@ module.exports = (content) => {
 
 	if (content.mainImage) {
 		baseSchema = { ...baseSchema, image: image(content.mainImage) };
+	}
+
+	if (content.posts && Array.isArray(content.posts)) {
+		baseSchema = {
+			...baseSchema,
+			liveBlogUpdate: content.posts.map(e => getLiveBlogPostingSchemaFromPost(e))
+		};
 	}
 
 	return baseSchema;


### PR DESCRIPTION
The current implementation of the schema doesn't show the live indicator on google searches. 

After comparing multiple implementations I realised the live indicator is linked to the liveblogUpdate field.

