### PR TITLE
set date modified field to be the publishedDate of the first post

### DIFF
--- a/test/types/liveblog.spec.js
+++ b/test/types/liveblog.spec.js
@@ -106,4 +106,11 @@ describe('Type: liveBlogPosting', function () {
 		});
 	});
 
+	context('dateModified field', function () {
+		it('should have dateModified should equal date published field of first post if posts field exists', () => {
+			const result = liveblog({ 'publishedDate': '2021-03-25T22:44:55.577Z', 'firstPublishedDate': '2021-03-25T00:14:12.161Z', posts });
+			expect(result.dateModified).to.equal(posts[0].publishedDate);
+		});
+	});
+
 });

--- a/types/liveblog.js
+++ b/types/liveblog.js
@@ -56,6 +56,14 @@ function getLiveBlogDescription (content) {
 	return '';
 }
 
+function getDateModified (content) {
+	if(content.posts && content.posts[0].publishedDate) {
+		return content.posts[0].publishedDate;
+	}
+
+	return content.publishedDate;
+}
+
 function getLiveBlogPostingSchemaFromPost (post) {
 	let baseSchema = {
 		'@type': 'BlogPosting'
@@ -67,6 +75,7 @@ function getLiveBlogPostingSchemaFromPost (post) {
 
 	if (post.publishedDate) {
 		baseSchema.datePublished = post.publishedDate;
+		baseSchema.dateModified = post.publishedDate;
 	}
 
 	if (post.mainImage) {
@@ -91,7 +100,7 @@ module.exports = (content) => {
 		'url': content.canonicalUrl,
 		'headline': content.title,
 		'datePublished': content.firstPublishedDate || content.publishedDate,
-		'dateModified': content.publishedDate,
+		'dateModified': getDateModified(content),
 		'isAccessibleForFree': content.accessLevel && content.accessLevel === 'free' ? 'True' : 'False'
 	};
 


### PR DESCRIPTION
This PR tries to fix the time difference in `last update` between google latest news and actual liveblog on ft.

<img width="696" alt="Screenshot 2021-05-19 at 09 55 12" src="https://user-images.githubusercontent.com/5596564/118785038-5ff6b980-b888-11eb-9648-a99ae36f7ebe.png">
<img width="876" alt="Screenshot 2021-05-19 at 09 55 23" src="https://user-images.githubusercontent.com/5596564/118785073-684ef480-b888-11eb-93ab-432f755361ed.png">
