### PR TITLE
Don't transform bodyHTML to plain text

### DIFF
--- a/test/fixtures/liveblog.json
+++ b/test/fixtures/liveblog.json
@@ -9,6 +9,7 @@
             },
             "webUrl": "https://www.ft.com/content",
             "publishedDate": "2021-05-12T22:30:36.929Z",
+            "bodyText": "Hello I'm plain body text.",
             "bodyHTML": "<p>Hello I'm <blink>HTML</blink>!</p>",
             "title": "Lorem Ipsum",
             "byline": "Anna Gross and John Burn-Murdoch in London, Amy Kazmin and Jyotsna Singh in New Delhi",
@@ -23,8 +24,7 @@
             },
             "webUrl": "https://www.ft.com/content",
             "publishedDate": "2021-05-12T22:29:42.706Z",
-            "bodyText": "Hello I'm plain body text.",
-            "bodyHTML": "<p>Lorem ipsum</p>",
+            "bodyHTML": "<p>Hello I'm <blink>HTML</blink>!</p>",
             "title": "Lorem ipsum",
             "byline": "FT reporters",
             "url": "https://www.ft.com/content"

--- a/test/types/article.spec.js
+++ b/test/types/article.spec.js
@@ -15,11 +15,11 @@ describe('Type: Article', function () {
 			});
 			expect(result.articleBody).to.equal('Hello, World.');
 		});
-		it('turns body HTML into text if available', function () {
+		it('does not turn body HTML into text', function () {
 			const result = article({
 				bodyHTML: '<p>Hello I\'m <blink>HTML</blink>!</p>',
 			});
-			expect(result.articleBody).to.equal('Hello I\'m HTML!');
+			expect(result.articleBody).to.be.undefined;
 		});
 	});
 

--- a/test/types/liveblog.spec.js
+++ b/test/types/liveblog.spec.js
@@ -95,7 +95,6 @@ describe('Type: liveBlogPosting', function () {
 
 	});
 
-
 	context('liveBlogUpdate field', function () {
 		it('should have liveBlogUpdate field if liveblogpackage has posts field', () => {
 			const result = liveblog({ 'publishedDate': '2021-03-25T22:44:55.577Z', 'firstPublishedDate': '2021-03-25T00:14:12.161Z', posts });
@@ -107,16 +106,15 @@ describe('Type: liveBlogPosting', function () {
 
 	context('articleBody field', function () {
 		it('uses the content bodyText property', () => {
-			const postWithBodyText = posts[1];
+			const postWithBodyText = posts[0];
 			const result = liveblog({ posts: [postWithBodyText] });
 			expect(result.liveBlogUpdate[0].articleBody).to.equal(postWithBodyText.bodyText);
 		});
 
-		it('transforms the content bodyHTML to plain text when no bodyText is available', () => {
-			const postWithoutBodyText = posts[0];
+		it('doesn\'t use the content bodyHTML when bodyText is unavailable', () => {
+			const postWithoutBodyText = posts[1];
 			const result = liveblog({ posts: [postWithoutBodyText] });
-			expect(result.liveBlogUpdate[0].articleBody).to.equal('Hello I\'m HTML!');
-			expect(result.liveBlogUpdate[1].articleBody).to.equal('Hello I\'m plain body text.');
+			expect(result.liveBlogUpdate[0].articleBody).to.be.undefined;
 		});
 	});
 

--- a/test/types/liveblog.spec.js
+++ b/test/types/liveblog.spec.js
@@ -116,6 +116,7 @@ describe('Type: liveBlogPosting', function () {
 			const postWithoutBodyText = posts[0];
 			const result = liveblog({ posts: [postWithoutBodyText] });
 			expect(result.liveBlogUpdate[0].articleBody).to.equal('Hello I\'m HTML!');
+			expect(result.liveBlogUpdate[1].articleBody).to.equal('Hello I\'m plain body text.');
 		});
 	});
 

--- a/types/article.js
+++ b/types/article.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { compile } = require('html-to-text');
 const wordcount = require('wordcount');
 const image = require('./image');
 const person = require('./person');
@@ -8,15 +7,9 @@ const organization = require('./organization');
 const product = require('./product');
 const ftData = require('../data/ft');
 
-const htmlToText = compile({ignoreHref: true});
-
 function getArticleBody (content) {
 	if (content.bodyText) {
 		return content.bodyText;
-	}
-
-	if (content.bodyHTML) {
-		return htmlToText(content.bodyHTML);
 	}
 
 	return '';

--- a/types/liveblog.js
+++ b/types/liveblog.js
@@ -90,8 +90,6 @@ function getLiveBlogPostingSchemaFromPost (post) {
 
 	if (post.bodyText) {
 		baseSchema.articleBody = post.bodyText;
-	} else if (post.bodyHTML) {
-		baseSchema.articleBody = htmlToText(post.bodyHTML);
 	}
 
 	return baseSchema;


### PR DESCRIPTION
Until this change, article and blog post bodyHTML would be transformed
into plain text if no plain bodyText was present. bodyText is almost always
available when the content is retrieved from Next ElasticSearch.
However, this can be very slow to perform for long articles. If Next
ElasticSearch suddenly didn't have this data for some reason, every
article page request would have to do this transformation.

It's an optional property, so probably not worth risking the
application resources on it if this were to happen [^1].

The only Articles without bodyText in Next Elastic seem to be
decommissioned Alphaville content that actually redirects to the Alphaville
stream page.

For Live Blog summaries the functionality remains the same: we're still
tranforming that HTML to plain text because plainText isn't present in
Next ElasticSearch (perhaps it ought to be?).

[^1]: https://developers.google.com/search/docs/advanced/structured-data/article#non-amp-sd