### PR TITLE
Support empty live blogs with no posts

### DIFF
--- a/types/liveblog.js
+++ b/types/liveblog.js
@@ -59,7 +59,7 @@ function getLiveBlogDescription (content) {
 }
 
 function getDateModified (content) {
-	if(content.posts && content.posts[0].publishedDate) {
+	if(Array.isArray(content.posts) && content.posts[0].publishedDate) {
 		return content.posts[0].publishedDate;
 	}
 
@@ -122,7 +122,7 @@ module.exports = (content) => {
 		baseSchema = { ...baseSchema, image: image(content.mainImage) };
 	}
 
-	if (content.posts && Array.isArray(content.posts)) {
+	if (Array.isArray(content.posts)) {
 		baseSchema = {
 			...baseSchema,
 			liveBlogUpdate: content.posts.map(e => getLiveBlogPostingSchemaFromPost(e))

--- a/types/liveblog.js
+++ b/types/liveblog.js
@@ -59,7 +59,7 @@ function getLiveBlogDescription (content) {
 }
 
 function getDateModified (content) {
-	if(Array.isArray(content.posts) && content.posts[0].publishedDate) {
+	if(Array.isArray(content.posts) && content.posts.length > 0 && content.posts[0].publishedDate) {
 		return content.posts[0].publishedDate;
 	}
 


### PR DESCRIPTION
[Slack thread for context](https://financialtimes.slack.com/archives/CSH1XFM5W/p1648823751711339)

Looking at next-article's failing tests and the live blog code there's a problem over in that repo. While adding this makes the code more robust, this part of the code hasn't change, so presumably the change is on the caller side?