### PR TITLE
return null breadcrumb ld when there are no items

### DIFF
--- a/test/types/breadcrumb.spec.js
+++ b/test/types/breadcrumb.spec.js
@@ -131,7 +131,6 @@ describe('Type: Breadcrumb', function () {
 		auxArticle.displayConcept = null;
 		delete auxArticle.displayConcept;
 		const result = breadcrumb(auxArticle);
-		expect(result).to.contain({ '@context': 'https://schema.org', '@type': 'BreadcrumbList' });
-		expect(result.itemListElement.length).to.equals(0);
+		expect(result).to.equal(null);
 	});
 });

--- a/types/breadcrumb.js
+++ b/types/breadcrumb.js
@@ -83,10 +83,14 @@ function getBreadcrumbItem (index,name,url){
 }
 
 module.exports = (content) => {
+	const items = getBreadcrumbItems(content);
+	if(!items || items.length <= 0)
+		return null;
+
 	const baseSchema = {
 		'@context': 'https://schema.org',
 		'@type': 'BreadcrumbList',
-		'itemListElement' : getBreadcrumbItems(content)
+		'itemListElement' : items
 	};
 
 	return baseSchema;


### PR DESCRIPTION
When we retrieve an empty ItemList in breadcrumb json ld this is see as an SEO error.  So now we retrieve null when there are no items on breadcrumb ld in order to not show the script with breadcrumb ld in those articles that do not have items valid for breadcrumb ld