### PR TITLE
fix: publish now requires matching version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@financial-times/next-json-ld",
-	"version": "0.0.0",
+	"version": "4.0.1",
 	"description": "Helpers for producing schema.org markup in JSON LD on ft.com",
 	"main": "main.js",
 	"devDependencies": {


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/Financial-Times/next-json-ld/1445/workflows/30570db2-baed-4293-8c64-7355990c03fd/jobs/4182 npm publish no longer accepts `0.0.0` as the version number in `package.json`