### PR TITLE
Remove snyk [automated]

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,0 @@
-# Snyk (https://snyk.io) policy file, which patches or ignores known vulnerabilities.
-version: v1.13.5
-ignore: {}
-patch: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@financial-times/next-json-ld",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@financial-times/next-json-ld",
-			"version": "4.0.2",
+			"version": "4.0.3",
 			"hasInstallScript": true,
 			"dependencies": {
 				"moment": "^2.29.1",
@@ -33,8 +33,7 @@
 				"lintspaces-cli": "^0.6.0",
 				"mocha": "^6.0.0",
 				"npm-prepublish": "^1.2.2",
-				"proxyquire": "^1.8.0",
-				"snyk": "^1.168.0"
+				"proxyquire": "^1.8.0"
 			},
 			"engines": {
 				"node": "18.x || 20.x",
@@ -1940,76 +1939,6 @@
 				"@octokit/openapi-types": "^12.11.0"
 			}
 		},
-		"node_modules/@sentry-internal/tracing": {
-			"version": "7.68.0",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.68.0.tgz",
-			"integrity": "sha512-nNKS/q21+Iqzxs2K7T/l3dZi8Z9s/uxsAazpk2AYhFzx9mFnPj1Xfe3dgbFoygNifE+IrpUuldr6D5HQamTDPQ==",
-			"dev": true,
-			"dependencies": {
-				"@sentry/core": "7.68.0",
-				"@sentry/types": "7.68.0",
-				"@sentry/utils": "7.68.0",
-				"tslib": "^2.4.1 || ^1.9.3"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@sentry/core": {
-			"version": "7.68.0",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.68.0.tgz",
-			"integrity": "sha512-mT3ObBWgvAky/QF3dZy4KBoXbRXbNsD6evn+mYi9UEeIZQ5NpnQYDEp78mapiEjI/TAHZIhTIuaBhj1Jk0qUUA==",
-			"dev": true,
-			"dependencies": {
-				"@sentry/types": "7.68.0",
-				"@sentry/utils": "7.68.0",
-				"tslib": "^2.4.1 || ^1.9.3"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@sentry/node": {
-			"version": "7.68.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.68.0.tgz",
-			"integrity": "sha512-gtcHoi6Xu6Iu8MpPgKJA4E0nozqLvYF0fKtt+27T0QBzWioO6lkxSQkKGWMyJGL0AmpLCex0E28fck/rlbt0LA==",
-			"dev": true,
-			"dependencies": {
-				"@sentry-internal/tracing": "7.68.0",
-				"@sentry/core": "7.68.0",
-				"@sentry/types": "7.68.0",
-				"@sentry/utils": "7.68.0",
-				"cookie": "^0.4.1",
-				"https-proxy-agent": "^5.0.0",
-				"lru_map": "^0.3.3",
-				"tslib": "^2.4.1 || ^1.9.3"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@sentry/types": {
-			"version": "7.68.0",
-			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.68.0.tgz",
-			"integrity": "sha512-5J2pH1Pjx/029zTm3CNY9MaE8Aui81nG7JCtlMp7uEfQ//9Ja4d4Sliz/kV4ARbkIKUZerSgaRAm3xCy5XOXLg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@sentry/utils": {
-			"version": "7.68.0",
-			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.68.0.tgz",
-			"integrity": "sha512-NecnQegvKARyeFmBx7mYmbI17mTvjARWs1nfzY5jhPyNc3Zk4M3bQsgIdnJ1t+jo93UYudlNND7hxhDzjcBAVg==",
-			"dev": true,
-			"dependencies": {
-				"@sentry/types": "7.68.0",
-				"tslib": "^2.4.1 || ^1.9.3"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.27.8",
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -3312,12 +3241,6 @@
 			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
 			"dev": true
 		},
-		"node_modules/boolean": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-			"integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-			"dev": true
-		},
 		"node_modules/bowser": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -3855,15 +3778,6 @@
 			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
 			"dev": true
 		},
-		"node_modules/cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/cookiejar": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
@@ -4031,12 +3945,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
 			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-			"dev": true
-		},
-		"node_modules/detect-node": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
 		},
 		"node_modules/diff": {
@@ -4379,12 +4287,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/es6-error": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-			"dev": true
 		},
 		"node_modules/es6-promise": {
 			"version": "2.3.0",
@@ -5157,23 +5059,6 @@
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/global-agent": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-			"integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-			"dev": true,
-			"dependencies": {
-				"boolean": "^3.0.1",
-				"es6-error": "^4.1.1",
-				"matcher": "^3.0.0",
-				"roarr": "^2.15.3",
-				"semver": "^7.3.2",
-				"serialize-error": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=10.0"
-			}
 		},
 		"node_modules/globals": {
 			"version": "13.21.0",
@@ -6283,12 +6168,6 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
 		},
-		"node_modules/json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-			"dev": true
-		},
 		"node_modules/jsonc-parser": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
@@ -6512,12 +6391,6 @@
 				"get-func-name": "^2.0.0"
 			}
 		},
-		"node_modules/lru_map": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-			"integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==",
-			"dev": true
-		},
 		"node_modules/lru-cache": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -6582,18 +6455,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/matcher": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-			"integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-			"dev": true,
-			"dependencies": {
-				"escape-string-regexp": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/merge-descriptors": {
@@ -8729,23 +8590,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/roarr": {
-			"version": "2.15.4",
-			"resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-			"integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-			"dev": true,
-			"dependencies": {
-				"boolean": "^3.0.1",
-				"detect-node": "^2.0.4",
-				"globalthis": "^1.0.1",
-				"json-stringify-safe": "^5.0.1",
-				"semver-compare": "^1.0.0",
-				"sprintf-js": "^1.1.2"
-			},
-			"engines": {
-				"node": ">=8.0"
-			}
-		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8882,7 +8726,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
 			"integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/semver-regex": {
 			"version": "3.1.4",
@@ -8914,33 +8759,6 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"node_modules/serialize-error": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-			"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^0.13.1"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/serialize-error/node_modules/type-fest": {
-			"version": "0.13.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-			"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.1",
@@ -9058,23 +8876,6 @@
 				"npm": ">= 3.0.0"
 			}
 		},
-		"node_modules/snyk": {
-			"version": "1.1216.0",
-			"resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1216.0.tgz",
-			"integrity": "sha512-xVEiPPyVenHZ2DKSK/tbHolatcMDlW0QCs/0ZNPhNqxSYzX65mKkL9+R4rxRXyeYckfq69gSDMTTuBf9c5zFqQ==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"@sentry/node": "^7.36.0",
-				"global-agent": "^3.0.0"
-			},
-			"bin": {
-				"snyk": "bin/snyk"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/socks": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
@@ -9173,12 +8974,6 @@
 			"engines": {
 				"node": ">= 10.x"
 			}
-		},
-		"node_modules/sprintf-js": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-			"dev": true
 		},
 		"node_modules/ssri": {
 			"version": "8.0.1",
@@ -12135,61 +11930,6 @@
 				"@octokit/openapi-types": "^12.11.0"
 			}
 		},
-		"@sentry-internal/tracing": {
-			"version": "7.68.0",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.68.0.tgz",
-			"integrity": "sha512-nNKS/q21+Iqzxs2K7T/l3dZi8Z9s/uxsAazpk2AYhFzx9mFnPj1Xfe3dgbFoygNifE+IrpUuldr6D5HQamTDPQ==",
-			"dev": true,
-			"requires": {
-				"@sentry/core": "7.68.0",
-				"@sentry/types": "7.68.0",
-				"@sentry/utils": "7.68.0",
-				"tslib": "^2.4.1 || ^1.9.3"
-			}
-		},
-		"@sentry/core": {
-			"version": "7.68.0",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.68.0.tgz",
-			"integrity": "sha512-mT3ObBWgvAky/QF3dZy4KBoXbRXbNsD6evn+mYi9UEeIZQ5NpnQYDEp78mapiEjI/TAHZIhTIuaBhj1Jk0qUUA==",
-			"dev": true,
-			"requires": {
-				"@sentry/types": "7.68.0",
-				"@sentry/utils": "7.68.0",
-				"tslib": "^2.4.1 || ^1.9.3"
-			}
-		},
-		"@sentry/node": {
-			"version": "7.68.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.68.0.tgz",
-			"integrity": "sha512-gtcHoi6Xu6Iu8MpPgKJA4E0nozqLvYF0fKtt+27T0QBzWioO6lkxSQkKGWMyJGL0AmpLCex0E28fck/rlbt0LA==",
-			"dev": true,
-			"requires": {
-				"@sentry-internal/tracing": "7.68.0",
-				"@sentry/core": "7.68.0",
-				"@sentry/types": "7.68.0",
-				"@sentry/utils": "7.68.0",
-				"cookie": "^0.4.1",
-				"https-proxy-agent": "^5.0.0",
-				"lru_map": "^0.3.3",
-				"tslib": "^2.4.1 || ^1.9.3"
-			}
-		},
-		"@sentry/types": {
-			"version": "7.68.0",
-			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.68.0.tgz",
-			"integrity": "sha512-5J2pH1Pjx/029zTm3CNY9MaE8Aui81nG7JCtlMp7uEfQ//9Ja4d4Sliz/kV4ARbkIKUZerSgaRAm3xCy5XOXLg==",
-			"dev": true
-		},
-		"@sentry/utils": {
-			"version": "7.68.0",
-			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.68.0.tgz",
-			"integrity": "sha512-NecnQegvKARyeFmBx7mYmbI17mTvjARWs1nfzY5jhPyNc3Zk4M3bQsgIdnJ1t+jo93UYudlNND7hxhDzjcBAVg==",
-			"dev": true,
-			"requires": {
-				"@sentry/types": "7.68.0",
-				"tslib": "^2.4.1 || ^1.9.3"
-			}
-		},
 		"@sinclair/typebox": {
 			"version": "0.27.8",
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -13265,12 +13005,6 @@
 			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
 			"dev": true
 		},
-		"boolean": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-			"integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-			"dev": true
-		},
 		"bowser": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -13683,12 +13417,6 @@
 			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
 			"dev": true
 		},
-		"cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-			"dev": true
-		},
 		"cookiejar": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
@@ -13814,12 +13542,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
 			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-			"dev": true
-		},
-		"detect-node": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
 		},
 		"diff": {
@@ -14101,12 +13823,6 @@
 				"is-date-object": "^1.0.1",
 				"is-symbol": "^1.0.2"
 			}
-		},
-		"es6-error": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-			"dev": true
 		},
 		"es6-promise": {
 			"version": "2.3.0",
@@ -14676,20 +14392,6 @@
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
 			"dev": true,
 			"peer": true
-		},
-		"global-agent": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-			"integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-			"dev": true,
-			"requires": {
-				"boolean": "^3.0.1",
-				"es6-error": "^4.1.1",
-				"matcher": "^3.0.0",
-				"roarr": "^2.15.3",
-				"semver": "^7.3.2",
-				"serialize-error": "^7.0.1"
-			}
 		},
 		"globals": {
 			"version": "13.21.0",
@@ -15480,12 +15182,6 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
 		},
-		"json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-			"dev": true
-		},
 		"jsonc-parser": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
@@ -15673,12 +15369,6 @@
 				"get-func-name": "^2.0.0"
 			}
 		},
-		"lru_map": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-			"integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==",
-			"dev": true
-		},
 		"lru-cache": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -15736,15 +15426,6 @@
 			"integrity": "sha512-cywKmeeoNFi//GGLHZ+Zb/M3ZX0VTwJjotLMWhDZoBRtSbw3kraIuIxw7P/xy+t5NSAMHNVeljM63WRBYQ563w==",
 			"requires": {
 				"word-regex": "^0.1.0"
-			}
-		},
-		"matcher": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-			"integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-			"dev": true,
-			"requires": {
-				"escape-string-regexp": "^4.0.0"
 			}
 		},
 		"merge-descriptors": {
@@ -17415,20 +17096,6 @@
 				"glob": "^7.1.3"
 			}
 		},
-		"roarr": {
-			"version": "2.15.4",
-			"resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-			"integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-			"dev": true,
-			"requires": {
-				"boolean": "^3.0.1",
-				"detect-node": "^2.0.4",
-				"globalthis": "^1.0.1",
-				"json-stringify-safe": "^5.0.1",
-				"semver-compare": "^1.0.0",
-				"sprintf-js": "^1.1.2"
-			}
-		},
 		"run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -17529,7 +17196,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
 			"integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"semver-regex": {
 			"version": "3.1.4",
@@ -17537,23 +17205,6 @@
 			"integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
 			"dev": true,
 			"peer": true
-		},
-		"serialize-error": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-			"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-			"dev": true,
-			"requires": {
-				"type-fest": "^0.13.1"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.13.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-					"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-					"dev": true
-				}
-			}
 		},
 		"serialize-javascript": {
 			"version": "6.0.1",
@@ -17654,16 +17305,6 @@
 			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
 			"dev": true
 		},
-		"snyk": {
-			"version": "1.1216.0",
-			"resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1216.0.tgz",
-			"integrity": "sha512-xVEiPPyVenHZ2DKSK/tbHolatcMDlW0QCs/0ZNPhNqxSYzX65mKkL9+R4rxRXyeYckfq69gSDMTTuBf9c5zFqQ==",
-			"dev": true,
-			"requires": {
-				"@sentry/node": "^7.36.0",
-				"global-agent": "^3.0.0"
-			}
-		},
 		"socks": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
@@ -17748,12 +17389,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
 			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-			"dev": true
-		},
-		"sprintf-js": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
 			"dev": true
 		},
 		"ssri": {

--- a/package.json
+++ b/package.json
@@ -24,15 +24,14 @@
 		"lintspaces-cli": "^0.6.0",
 		"mocha": "^6.0.0",
 		"npm-prepublish": "^1.2.2",
-		"proxyquire": "^1.8.0",
-		"snyk": "^1.168.0"
+		"proxyquire": "^1.8.0"
 	},
 	"dependencies": {
 		"moment": "^2.29.1",
 		"wordcount": "^1.1.1"
 	},
 	"scripts": {
-		"prepare": "npx snyk protect || npx snyk protect -d || true && husky install",
+		"prepare": "husky install",
 		"preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine",
 		"format": "dotcom-tool-kit format:local",
 		"build": "dotcom-tool-kit build:local",


### PR DESCRIPTION
In mid-December 2024 we will be letting our Snyk contract expire. We'll
be moving to GitHub Advanced Security as an alternative.

This PR is an attempt to get ahead of the deadline. Considering how out
of date some of our Snyk implementations are, and that we rarely take
the time to merge the PRs, we think it's fine to remove it way ahead of
time.

If you want an interrim solution, enable Dependabot Security updates for
this repository by visiting the following page and clicking 'Enable' next
to 'Dependabot security updates':
https://github.com/Financial-Times/next-json-ld/settings/security_analysis

You're also free to ignore this PR and do the work yourself closer to
the deadline. Cyber will be doing some broader comms later in the year.

This PR was automated, please take a little extra care when reviewing. I
won't be attempting to fix build failures or small repo-specific quirks
but feel free to build on top of this PR.