### PR TITLE
fix: use update date instead of published date

### DIFF
--- a/test/fixtures/liveblog.json
+++ b/test/fixtures/liveblog.json
@@ -9,6 +9,7 @@
 			},
 			"webUrl": "https://www.ft.com/content",
 			"publishedDate": "2021-05-12T22:30:36.929Z",
+			"modifiedTimestamp": 1620859836929,
 			"bodyText": "Hello I'm plain body text.",
 			"bodyHTML": "<p>Hello I'm <blink>HTML</blink>!</p>",
 			"title": "Lorem Ipsum",

--- a/test/types/article.spec.js
+++ b/test/types/article.spec.js
@@ -80,14 +80,16 @@ describe('Type: Article', function () {
 			const modifiedTimestamp = 1620859836929;
 			const articleData = {
 				modifiedTimestamp,
-				publishedDate: "2021-05-12T22:30:36.929Z"
+				publishedDate: '2021-05-12T22:30:36.929Z'
 			};
 			const result = article(articleData);
-			expect(result.dateModified).to.equal(new Date(modifiedTimestamp).toISOString());
+			expect(result.dateModified).to.equal(
+				new Date(modifiedTimestamp).toISOString()
+			);
 		});
 
 		it('defaults to using publishedDate', () => {
-			const publishedDate = "2021-05-12T22:30:36.929Z";
+			const publishedDate = '2021-05-12T22:30:36.929Z';
 			const articleData = {
 				publishedDate
 			};

--- a/test/types/article.spec.js
+++ b/test/types/article.spec.js
@@ -74,4 +74,25 @@ describe('Type: Article', function () {
 			});
 		});
 	});
+
+	context('Date modified', () => {
+		it('uses the modified timestamp if there is one', () => {
+			const modifiedTimestamp = 1620859836929;
+			const articleData = {
+				modifiedTimestamp,
+				publishedDate: "2021-05-12T22:30:36.929Z"
+			};
+			const result = article(articleData);
+			expect(result.dateModified).to.equal(new Date(modifiedTimestamp).toISOString());
+		});
+
+		it('defaults to using publishedDate', () => {
+			const publishedDate = "2021-05-12T22:30:36.929Z";
+			const articleData = {
+				publishedDate
+			};
+			const result = article(articleData);
+			expect(result.dateModified).to.equal(publishedDate);
+		});
+	});
 });

--- a/test/types/liveblog.spec.js
+++ b/test/types/liveblog.spec.js
@@ -158,13 +158,46 @@ describe('Type: liveBlogPosting', function () {
 	});
 
 	context('dateModified field', function () {
-		it('should have dateModified should equal date published field of first post if posts field exists', () => {
+		it('should set dateModified to equal modified date of first post if posts field exists', () => {
 			const result = liveblog({
 				publishedDate: '2021-03-25T22:44:55.577Z',
 				firstPublishedDate: '2021-03-25T00:14:12.161Z',
 				posts
 			});
-			expect(result.dateModified).to.equal(posts[0].publishedDate);
+			const modifiedDate = new Date(posts[0].modifiedTimestamp).toISOString();
+			expect(result.dateModified).to.equal(modifiedDate);
+		});
+
+		it('should set dateModified to equal published date of first post if date modified does not exist', () => {
+			const noModDatePosts = [posts[1]];
+			const result = liveblog({
+				publishedDate: '2021-03-25T22:44:55.577Z',
+				firstPublishedDate: '2021-03-25T00:14:12.161Z',
+				posts: noModDatePosts
+			});
+			expect(result.dateModified).to.equal(posts[1].publishedDate);
+		});
+
+		it('should set dateModified to equal modified date of article if there are no live blog posts', () => {
+			const modifiedTimestamp = 1616715295577;
+			const result = liveblog({
+				publishedDate: '2021-03-25T22:44:55.577Z',
+				firstPublishedDate: '2021-03-25T00:14:12.161Z',
+				modifiedTimestamp,
+				posts: []
+			});
+			const modifiedDate = new Date(modifiedTimestamp).toISOString();
+			expect(result.dateModified).to.equal(modifiedDate);
+		});
+
+		it('should set dateModified to equal published date of article if there are no live blog posts and no date modified', () => {
+			const publishedDate = '2021-03-25T22:44:55.577Z';
+			const result = liveblog({
+				publishedDate,
+				firstPublishedDate: '2021-03-25T00:14:12.161Z',
+				posts: []
+			});
+			expect(result.dateModified).to.equal(publishedDate);
 		});
 	});
 });

--- a/types/article.js
+++ b/types/article.js
@@ -24,7 +24,9 @@ module.exports = (content) => {
 		datePublished: content.initialPublishedDate
 			? content.initialPublishedDate
 			: content.publishedDate,
-		dateModified: content.publishedDate,
+		dateModified: content.modifiedTimestamp
+			? new Date(content.modifiedTimestamp).toISOString()
+			: content.publishedDate,
 		description: content.description,
 		isAccessibleForFree:
 			content.accessLevel && content.accessLevel === 'free' ? 'True' : 'False'

--- a/types/liveblog.js
+++ b/types/liveblog.js
@@ -63,13 +63,13 @@ function getDateModified(content) {
 		content.posts[0].publishedDate
 	) {
 		// If modifiedTimestamp exists, use it. Otherwise, use publishedDate.
-		return (content.posts[0].modifiedTimestamp)
+		return content.posts[0].modifiedTimestamp
 			? new Date(content.posts[0].modifiedTimestamp).toISOString()
 			: content.posts[0].publishedDate;
 	}
 
 	// If modifiedTimestamp exists, use it. Otherwise, use publishedDate.
-	return (content.modifiedTimestamp)
+	return content.modifiedTimestamp
 		? new Date(content.modifiedTimestamp).toISOString()
 		: content.publishedDate;
 }

--- a/types/liveblog.js
+++ b/types/liveblog.js
@@ -86,7 +86,7 @@ function getLiveBlogPostingSchemaFromPost(post) {
 
 	if (post.publishedDate) {
 		baseSchema.datePublished = post.publishedDate;
-		baseSchema.dateModified = post.publishedDate;
+		baseSchema.dateModified = post.modifiedTimestamp ? new Date(post.modifiedTimestamp).toISOString() : post.publishedDate;
 	}
 
 	if (post.mainImage) {

--- a/types/liveblog.js
+++ b/types/liveblog.js
@@ -86,7 +86,9 @@ function getLiveBlogPostingSchemaFromPost(post) {
 
 	if (post.publishedDate) {
 		baseSchema.datePublished = post.publishedDate;
-		baseSchema.dateModified = post.modifiedTimestamp ? new Date(post.modifiedTimestamp).toISOString() : post.publishedDate;
+		baseSchema.dateModified = post.modifiedTimestamp
+			? new Date(post.modifiedTimestamp).toISOString()
+			: post.publishedDate;
 	}
 
 	if (post.mainImage) {

--- a/types/liveblog.js
+++ b/types/liveblog.js
@@ -56,23 +56,22 @@ function getLiveBlogDescription(content) {
 }
 
 function getDateModified(content) {
+	// use the latest blog post date if it exists
 	if (
 		Array.isArray(content.posts) &&
 		content.posts.length > 0 &&
 		content.posts[0].publishedDate
 	) {
 		// If modifiedTimestamp exists, use it. Otherwise, use publishedDate.
-		if (content.posts[0].modifiedTimestamp) {
-			return new Date(content.posts[0].modifiedTimestamp).toISOString();
-		}
-		return content.posts[0].publishedDate;
+		return (content.posts[0].modifiedTimestamp)
+			? new Date(content.posts[0].modifiedTimestamp).toISOString()
+			: content.posts[0].publishedDate;
 	}
 
 	// If modifiedTimestamp exists, use it. Otherwise, use publishedDate.
-	if (content.modifiedTimestamp) {
-		return new Date(content.modifiedTimestamp).toISOString();
-	}
-	return content.publishedDate;
+	return (content.modifiedTimestamp)
+		? new Date(content.modifiedTimestamp).toISOString()
+		: content.publishedDate;
 }
 
 function getLiveBlogPostingSchemaFromPost(post) {

--- a/types/liveblog.js
+++ b/types/liveblog.js
@@ -61,9 +61,17 @@ function getDateModified(content) {
 		content.posts.length > 0 &&
 		content.posts[0].publishedDate
 	) {
+		// If modifiedTimestamp exists, use it. Otherwise, use publishedDate.
+		if (content.posts[0].modifiedTimestamp) {
+			return new Date(content.posts[0].modifiedTimestamp).toISOString();
+		}
 		return content.posts[0].publishedDate;
 	}
 
+	// If modifiedTimestamp exists, use it. Otherwise, use publishedDate.
+	if (content.modifiedTimestamp) {
+		return new Date(content.modifiedTimestamp).toISOString();
+	}
 	return content.publishedDate;
 }
 


### PR DESCRIPTION
NewsArticle type before vs after changes

![image](https://github.com/user-attachments/assets/aebbf965-fe73-4b71-bb00-fe6045d25ec5)

BlogPosting type before vs after changes

![image](https://github.com/user-attachments/assets/4e6863b3-8932-46ce-b8ca-2ad8a883b3aa)

